### PR TITLE
Bugfix - Invoke-DownloadFile not working on MacOS

### DIFF
--- a/PsoDownloader/1.0.0/Get-BinaryDownloadCommand.ps1
+++ b/PsoDownloader/1.0.0/Get-BinaryDownloadCommand.ps1
@@ -1,5 +1,4 @@
-﻿function Get-BinaryDownloadCommand
-{
+﻿function Get-BinaryDownloadCommand {
   param
   (
     # path to download the executable to
@@ -8,42 +7,60 @@
     [ValidateNotNullOrEmpty()]
     $Path = "$env:temp$env:tmpdir"
   )
-    
+
   # tool is OS specific so lets figure out the correct tool name
-  
+
   # add PS7 variables to older powershell versions:
-  if ($PSVersionTable.PSVersion.Major -le 5) 
-  { 
-    $IsWindows = $true 
+  if ($PSVersionTable.PSVersion.Major -le 5) {
+    $IsWindows = $true
     $IsMacOs = $IsLinux = $false
   }
-  
-  # determine OS-specific tool executable name:
-  $toolname = 
-  if ($IsWindows) { 'yt-dlp_min.exe' }
-  elseif ($IsMacOs) { 'yt-dlp_macos' }
-  elseif ($IsLinux) { 'yt-dlp' }
-  
-  # already present?
-  $filepath = Join-Path -Path $Path -ChildPath yt-dlp_min.exe
-  $exists = Test-Path -Path $filepath
-  if ($exists) { return $filepath }
 
-  # no, let's download the latest release available (newest)
-  
+  # determine OS-specific tool executable name:
+
+  if ($IsWindows) { $toolname = 'yt-dlp_min.exe' }
+  elseif ($IsMacOs) {
+    $toolname = 'yt-dlp_macos'
+    $Path = $ENV:TMPDIR
+  } elseif ($IsLinux) { $toolname = 'yt-dlp' }
+
+  # already present?
+
+  if ($IsMacOs) {
+
+    $filepath = (Get-Command yt-dlp -ErrorAction Ignore).Source
+
+  } else {
+
+  $filepath = Join-Path -Path $Path -ChildPath $toolname
+
+}
+
+$exists = Test-Path -Path $filepath
+if ($exists) { return $filepath }
+
+
+# no, let's download the latest release available (newest)
+
   # first, find out the latest release number from github:
-  $info = Invoke-RestMethod -Uri https://github.com/yt-dlp/yt-dlp/releases/latest -Headers @{Accept='application/json'} -UseBasicParsing
+  $info = Invoke-RestMethod -Uri https://github.com/yt-dlp/yt-dlp/releases/latest -Headers @{Accept = 'application/json' } -UseBasicParsing
   $release = $info.tag_name
-    
+
   # second, construct the download path for the required OS-specific tool:
   $url = "https://github.com/yt-dlp/yt-dlp/releases/download/$release/$toolname"
-  
+
   # third, download the file and unblock it (on Windows)
   # make sure TLS1.2 is supported (on older Windows systems it may not)
   #l[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -band  [Net.SecurityProtocolType]::Tls12
-  Invoke-RestMethod -UseBasicParsing -Uri $url -OutFile $filepath
+  if ($IsMacOs) {
+    brew install yt-dlp/taps/yt-dlp
+    $filepath = (Get-Command yt-dlp).Source
+  } else {
+    $filepath = Invoke-RestMethod -Uri $url -Headers @{Accept = 'application/octet-stream' } -UseBasicParsing -OutFile $filepath
+    Invoke-RestMethod -UseBasicParsing -Uri $url -OutFile $filepath
+  }
   if ($IsWindows) { Unblock-File -Path $filepath }
-  
+
   # return the downloaded media file absolute path:
   return $filepath
 }


### PR DESCRIPTION
Fixes #1 

- The initial issue was that the default value for $Path was $null on MacOS, so I changed it to $Path = $ENV:TMPDIR
- The next issue was that a popup stating `yt-dlp_macos can’t be opened because Apple cannot check it for malicious software.` A possible solution for that may be installing it to /usr/local/bin/yt-dlp as suggested in the yt-dlp repository. However, I chose to install it using brew - as it also handles the needed dependencies and automatically installs it to /usr/local/bin/yt-dlp.

Tested the proposed changes using PowerShell 7.2.4 on MacOS Montery 12.4 where the following ran without any issues:
`Invoke-DownloadFile -Url https://www.youtube.com/watch?v=uoBptbPFOPk  -FolderPath /Users/janegilring/Movies`

Signed-off-by: Jan Egil Ring <jan.egil.ring@crayon.com>